### PR TITLE
Update sengled_base_url to non AWS URL

### DIFF
--- a/SengledElement/__init__.py
+++ b/SengledElement/__init__.py
@@ -1,4 +1,4 @@
-sengled_base_url = 'https://ec2-34-211-169-253.us-west-2.compute.amazonaws.com/'
+sengled_base_url = 'https://element.cloud.sengled.com/'
 zigbee_url = 'zigbee/'
 customer_url = 'customer/'
 device_url = 'device/'


### PR DESCRIPTION
AWS URL is prone to changing. Set it to the domain name that fronts AWS.